### PR TITLE
args.out <-> outname problem

### DIFF
--- a/bin/scTE
+++ b/bin/scTE
@@ -152,7 +152,7 @@ def main():
     info("Done fetching... %s \n"%(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")))
 
     info("Calculating expression... %s"%(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")))
-    len_res, genenumber, filename = Countexpression(filename=args.out, allelement=allelement, genenumber=args.genenumber, cellnumber=args.cellnumber, hdf5=args.hdf5)
+    len_res, genenumber, filename = Countexpression(filename=outname, allelement=allelement, genenumber=args.genenumber, cellnumber=args.cellnumber, hdf5=args.hdf5)
     info('Detect {0} cells expressed at least {1} genes, results output to {2}.csv'.format(len_res, genenumber, filename))
     info("Finished calculating expression %s"%(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")))
 


### PR DESCRIPTION
Hello,
I am PhD student working with single cell data
I read your research paper on TE quantification in single-cell data. Very witty!

It prompted me to try out your pipeline, but it crushed with an error soooo close to an end. I looked the source code on git hub, and it seems I had found the source of an error.

At the line 155 where the `Counterexpression` function is called, for a `filename` argument it takes `args.out`, which is an output path specified by the user. Throughout the pipeline the `outname` ( `basename` of `args.out` ) is used, and all of the temporary files are saved to the working directory using the `outname` as a prefix for tmp folder. 

Thus, when `Counterexpression` is called with `args.out`, it looks for temporary files following incorrect paths;
from `base.py`:
```
def Countexpression(filename, allelement, genenumber, cellnumber, hdf5):
    gene_seen = allelement

    whitelist={}
    o = gzip.open('%s_scTEtmp/o4/%s.bed.gz'%(filename, filename), 'rt')
```

Temporarily changing args.out to outname solved this problem for me and pipeline ran smoothly. All the output files were saved to the directory from where the original script were run.